### PR TITLE
fix: incluir gasolina en sumatoria de nuevo documento

### DIFF
--- a/Components/DocumentWizard/index.jsx
+++ b/Components/DocumentWizard/index.jsx
@@ -566,7 +566,7 @@ export default function DocumentWizard (props) {
     const casetasTotal = computeConcept(data.casetas_amount, data.casetas_unit, data.casetas_days, 1)
     const operatorTotal = computeConcept(data.operator_rate, data.operator_unit, data.operator_days, diasPeriodo)
     const perDiemTotal = computeConcept(data.per_diem_rate, data.per_diem_unit, data.per_diem_days, diasPeriodo)
-    const gasolineTotal = computeConcept(data.gasoline_rate, data.gasoline_unit, 0, diasPeriodo)
+    const gasolineTotal = computeConcept(data.gasoline_rate, data.gasoline_unit, data.gasoline_km ?? '', diasPeriodo)
     const rentaTotal = computeConcept(data.unit_rent_amount, data.unit_rent_unit, data.unit_rent_qty, diasPeriodo)
 
     const subtotal = casetasTotal + operatorTotal + perDiemTotal + gasolineTotal + rentaTotal

--- a/Components/Modal/RentaConceptsBreakdown.jsx
+++ b/Components/Modal/RentaConceptsBreakdown.jsx
@@ -342,6 +342,7 @@ const RentaConceptsBreakdown = ({ planName, requestDate, deliveryDate }) => {
 
   const gasolineRate = Number(useWatch({ control, name: 'gasoline_rate' }) || 0)
   const gasolineUnit = useWatch({ control, name: 'gasoline_unit' }) || 'dia'
+  const gasolineKm = useWatch({ control, name: 'gasoline_km' })
 
   const unitRentAmount = Number(useWatch({ control, name: 'unit_rent_amount' }) || 0)
   const unitRentUnit = useWatch({ control, name: 'unit_rent_unit' }) || 'dia'
@@ -371,7 +372,7 @@ const RentaConceptsBreakdown = ({ planName, requestDate, deliveryDate }) => {
   const casetasTotal = computeConcept(casetasAmount, casetasUnit, casetasDays, 1)
   const operatorTotal = computeConcept(operatorRate, operatorUnit, operatorDays, diasPeriodo)
   const perDiemTotal = computeConcept(perDiemRate, perDiemUnit, perDiemDays, diasPeriodo)
-  const gasolineTotal = computeConcept(gasolineRate, gasolineUnit, 0, diasPeriodo)
+  const gasolineTotal = computeConcept(gasolineRate, gasolineUnit, gasolineKm ?? '', diasPeriodo)
   const rentaTotal = computeConcept(unitRentAmount, unitRentUnit, unitRentQty, diasPeriodo)
 
   const subtotal = casetasTotal + operatorTotal + perDiemTotal + gasolineTotal + rentaTotal


### PR DESCRIPTION
## Problema

Al crear un nuevo documento de salida, el **subtotal no incluía el concepto de gasolina**.

El agregador llamaba `computeConcept(gasolineRate, gasolineUnit, 0, diasPeriodo)` con `qty=0` hardcodeado. `computeConcept` solo cae al fallback de `dias` cuando qty es ``/`null`/`undefined`, no cuando es `0`, así que `gasolineTotal = rate × 0 = 0` siempre salvo unidad `fijo`. Además `gasoline_km` no se observaba. El renglón del acordeón mostraba el monto correcto pero el subtotal lo excluía.

## Fix

- Observar `gasoline_km` con `useWatch`.
- Pasar `gasoline_km ?? ` a `computeConcept` (cae a días si vacío).
- Aplicado en `RentaConceptsBreakdown.jsx` y en `StepResumen` de `DocumentWizard/index.jsx`.

## Pendiente

El payload de onSubmit no manda `iva`/`total`; backend debe recalcular `(subtotal + util% + indirect%) × 1.16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)