### PR TITLE
fix: accordion de conceptos no se cierra al teclear

### DIFF
--- a/Components/DocumentWizard/index.jsx
+++ b/Components/DocumentWizard/index.jsx
@@ -73,7 +73,7 @@ export default function DocumentWizard (props) {
 
   const [openNewVehicle, setOpenNewVehicle] = useState(false)
   const [newPlan, setNewPlan] = useState(false)
-  const planWatchSelected = watch('plan')
+  const planWatchSelected = useWatch({ control, name: 'plan' })
 
   const handledNewVehicle = (event) => setOpenNewVehicle(event)
   const handledNewPlan = (event) => setNewPlan(event)


### PR DESCRIPTION
watch('plan') usa el método watch de useForm, que en render suscribe a TODOS los cambios del form y re-renderiza DocumentWizard en cada tecla. Eso recrea el array stepContent con los Step* definidos inline (nueva identidad de función) y React remonta StepFacturacion, lo que resetea openKeys de RentaConceptsBreakdown y cierra el accordion. Se reemplaza por useWatch, que está scoped al campo 'plan'.